### PR TITLE
Adiciona campos de tipo de prova nas exportações de resultado

### DIFF
--- a/src/SME.SERAp.Prova.Aplicacao/Queries/ObterExportacaoResultadoProvasPorDataPaginada/ObterExportacaoResultadoProvasPorDataPaginadaQueryHandler.cs
+++ b/src/SME.SERAp.Prova.Aplicacao/Queries/ObterExportacaoResultadoProvasPorDataPaginada/ObterExportacaoResultadoProvasPorDataPaginadaQueryHandler.cs
@@ -38,6 +38,10 @@ namespace SME.SERAp.Prova.Aplicacao
                     CreateDate = x.CriadoEm.ToString("dd/MM/yyyy HH:mm:ss"),
                     UpdateDate = x.UltimaExportacao?.ToString("dd/MM/yyyy HH:mm:ss"),
                     FileId = x.ProcessoId,
+                    TipoId = x.TipoId,
+                    TipoLegadoId = x.TipoLegadoId,
+                    TipoDescricao = x.TipoDescricao,
+                    TipoParaEstudanteComDeficiencia = x.TipoParaEstudanteComDeficiencia
                 }),
                 TotalRegistros = result.TotalRegistros,
                 TotalPaginas = result.TotalPaginas

--- a/src/SME.SERAp.Prova.Dados/Repositorios/Serap/RepositorioExportacaoResultado.cs
+++ b/src/SME.SERAp.Prova.Dados/Repositorios/Serap/RepositorioExportacaoResultado.cs
@@ -38,7 +38,7 @@ namespace SME.SERAp.Prova.Dados
 
         public async Task<PaginacaoResultadoDto<ProvaExportacaoResultadoDto>> ObterPorFiltroDataPaginadaAsync(DateTime? dataInicio,
             DateTime? dataFim, long provaSerapId, string descricaoProva, int quantidadeRegistros, int numeroPagina)
-        {           
+        {
             const string query = @"select p.id as  ProvaId, 
                                         p.prova_legado_id as ProvaLegadoId,
                                         p.descricao as Descricao,
@@ -48,7 +48,13 @@ namespace SME.SERAp.Prova.Dados
                                         case when ex.id is null then 0 else ex.id end ProcessoId,
                                         case when ex.status is null then 1 else ex.status end Status,
                                         ex.criado_em as CriadoEm,
-                                        coalesce(ex.atualizado_em, ex.criado_em) as UltimaExportacao
+                                        coalesce(ex.atualizado_em, ex.criado_em) as UltimaExportacao,
+                                        tp.id as TipoId,
+                                        tp.legado_id as TipoLegadoId,
+                                        tp.descricao as TipoDescricao,
+                                        tp.para_estudante_com_deficiencia as TipoParaEstudanteComDeficiencia,
+                                        tp.criado_em as TipoCriadoEm,
+                                        tp.atualizado_em as TipoAtualizadoEm
                                     from prova p
                                     inner join (select distinct prova_id 
                                                 from prova_aluno
@@ -60,8 +66,9 @@ namespace SME.SERAp.Prova.Dados
                                                 having id = (select max(id) 
                                                                 from exportacao_resultado
                                                                 where prova_serap_id = ex.prova_serap_id)) as ex on p.prova_legado_id = ex.prova_serap_id
+                                    left join tipo_prova tp on tp.id = p.tipo_prova_id
                                     where 1 = 1";
-            
+
             const string queryCount = @"select count(1)
                                         from prova p
                                         inner join (select distinct prova_id
@@ -74,10 +81,11 @@ namespace SME.SERAp.Prova.Dados
                                                     having id = (select max(id) 
                                                                     from exportacao_resultado
                                                                     where prova_serap_id = ex.prova_serap_id)) as ex on p.prova_legado_id = ex.prova_serap_id
+                                        left join tipo_prova tp on tp.id = p.tipo_prova_id
                                         where 1 = 1";
 
             var retorno = new PaginacaoResultadoDto<ProvaExportacaoResultadoDto>();
-            
+
             using var conn = ObterConexaoLeitura();
             try
             {
@@ -100,7 +108,7 @@ namespace SME.SERAp.Prova.Dados
                 sql.AppendLine(" limit @quantidadeRegistros offset(@numeroPagina - 1) * @quantidadeRegistros; ");
 
                 sql.AppendLine(queryCount);
-                
+
                 if (dataInicio != null)
                     sql.AppendLine(" and p.inicio >= @DataInicio");
 
@@ -109,10 +117,10 @@ namespace SME.SERAp.Prova.Dados
 
                 if (provaSerapId > 0)
                     sql.AppendLine(" and p.prova_legado_id = @ProvaSerapId");
-                
+
                 if (!string.IsNullOrEmpty(descricaoProva))
-                    sql.AppendLine($" and lower(p.descricao) like '%{descricaoProva.ToLower()}%'");                
-                
+                    sql.AppendLine($" and lower(p.descricao) like '%{descricaoProva.ToLower()}%'");
+
                 using (var multi = await conn.QueryMultipleAsync(sql.ToString(), new { dataInicio, dataFim, provaSerapId, quantidadeRegistros, numeroPagina }))
                 {
                     retorno.Items = multi.Read<ProvaExportacaoResultadoDto>();

--- a/src/SME.SERAp.Prova.Infra/Dtos/ExportacaoResultado/ExportacaoRetornoSerapDto.cs
+++ b/src/SME.SERAp.Prova.Infra/Dtos/ExportacaoResultado/ExportacaoRetornoSerapDto.cs
@@ -1,11 +1,11 @@
 ﻿namespace SME.SERAp.Prova.Infra
 {
-    public class ExportacaoRetornoSerapDto : DtoBase
+	public class ExportacaoRetornoSerapDto : DtoBase
 	{
 		public long Test_Id { get; set; }
 		public string TestDescription { get; set; }
 		public string ApplicationStartDate { get; set; }
-		public string ApplicationEndDate { get; set; }        
+		public string ApplicationEndDate { get; set; }
 		public string TestTypeDescription { get; set; }
 		public int StateExecution { get; set; }
 
@@ -13,5 +13,10 @@
 		public string UpdateDate { get; set; }
 
 		public long FileId { get; set; }
-	}
+
+        public long? TipoId { get; set; }
+        public long? TipoLegadoId { get; set; }
+        public string TipoDescricao { get; set; }
+        public bool? TipoParaEstudanteComDeficiencia { get; set; }
+    }
 }

--- a/src/SME.SERAp.Prova.Infra/Dtos/ExportacaoResultado/ProvaExportacaoResultadoDto.cs
+++ b/src/SME.SERAp.Prova.Infra/Dtos/ExportacaoResultado/ProvaExportacaoResultadoDto.cs
@@ -15,5 +15,9 @@ namespace SME.SERAp.Prova.Infra
         public ExportacaoResultadoStatus Status { get; set; }
         public DateTime CriadoEm { get; set; }
         public DateTime? UltimaExportacao { get; set; }
+        public long? TipoId { get; set; }
+        public long? TipoLegadoId { get; set; }
+        public string TipoDescricao { get; set; }
+        public bool? TipoParaEstudanteComDeficiencia { get; set; }
     }
 }


### PR DESCRIPTION
Foram incluídos novos campos relacionados ao tipo de prova (TipoId, TipoLegadoId, TipoDescricao, TipoParaEstudanteComDeficiencia) nos DTOs de exportação. A consulta SQL foi ajustada com left join em tipo_prova para trazer esses dados. O handler e as queries de contagem/paginação foram atualizados para mapear e considerar os novos campos. Pequenas melhorias de formatação e organização de código também foram realizadas.